### PR TITLE
make sure loops are exited eventually

### DIFF
--- a/lib/Astro/Sunrise.pm
+++ b/lib/Astro/Sunrise.pm
@@ -67,6 +67,8 @@ sub sunrise  {
 
     my $tmp_rise_2 = 9;
     my $tmp_rise_3 = 0;
+
+    my $counter = 0;
     until (equal($tmp_rise_2, $tmp_rise_3, 8) )   {
 
        my $d_sunrise_1 = $d + $tmp_rise_1/24.0;
@@ -76,11 +78,13 @@ sub sunrise  {
        ($tmp_rise_3, undef) = sun_rise_set($d_sunrise_2, $lon, $lat, $altit, 15.04107, $arg{upper_limb}, $arg{polar});
 
        #print "tmp_rise2 is: $tmp_rise_2 tmp_rise_3 is:$tmp_rise_3\n";
+       last if ++$counter == 100;
     }
 
     my $tmp_set_2 = 9;
     my $tmp_set_3 = 0;
 
+    $counter = 0;
     until (equal($tmp_set_2, $tmp_set_3, 8) )   {
 
        my $d_sunset_1 = $d + $tmp_set_1/24.0;
@@ -91,6 +95,7 @@ sub sunrise  {
 
        #print "tmp_set_1 is: $tmp_set_1 tmp_set_3 is:$tmp_set_3\n";
 
+       last if ++$counter == 100;
     }
 
     return convert_hour($tmp_rise_3, $tmp_set_3, $TZ, $isdst);


### PR DESCRIPTION
We (http://geocoder.opencagedata.com/) found two edge cases were the calculation got stuck in an endless loop.

Test case `sunrise(2015,11,28, 177 , -37.66667 , 0, 0, 6, 1)`

(about 10km off the coast of Edgecumbe, New Zealand. http://www.openstreetmap.org/node/1580346642#map=9/-38.4697/176.7769)

It get stuck for Nov/28 and Nov/29, but it's fine for all other days. For the days I tested the loops were run 3 times so setting the maximum iterations to 100 seems reasonable.

After the fix the returned time-of-days don't look too much off.

November:
`perl -Ilib -E'use Astro::Sunrise; for(1..30){ say join( " | ",$_, sunrise(2015,11,$_, 177 , -37.66667 , 0, 0, 6, 1) )}'`

```
18 | 17:25 | 06:26
19 | 17:25 | 06:27
20 | 17:24 | 06:28
21 | 17:24 | 06:29
22 | 17:23 | 06:30
23 | 17:23 | 06:31
24 | 17:22 | 06:31
25 | 17:22 | 06:32
26 | 17:22 | 06:33
27 | 17:21 | 06:34
28 | 17:21 | 06:39 <--
29 | 17:21 | 06:39 <--
30 | 17:25 | 06:40
```

December
`perl -Ilib -E'use Astro::Sunrise; for(1..30){ say join( " | ",$_, sunrise(2015,12,$_, 177 , -37.66667 , 0, 0, 6, 1) )}'`

```
1 | 17:25 | 06:41
2 | 17:25 | 06:42
3 | 17:24 | 06:43
4 | 17:24 | 06:44
5 | 17:24 | 06:45
6 | 17:24 | 06:45
7 | 17:24 | 06:46
8 | 17:24 | 06:47
9 | 17:24 | 06:48
10 | 17:24 | 06:49
11 | 17:24 | 06:49
12 | 17:25 | 06:50
```
